### PR TITLE
Hotfix/game link a11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,9 +36,21 @@
     		<h1>Spirit Island</h1>
     		<p>Island Spirits join forces using elemental powers to defend their home from invaders.</p>
     		<div class="game_links">
-					<div class="game_link"><a href="https://boardgamegeek.com/boardgame/162886/spirit-island" target="_blank"><img src="images/bgg_logo.svg" class="game_card_logo"></a></div>
-					<div class="game_link"><a href="https://spiritislandwiki.com/index.php?title=Main_Page" target="_blank"><img src="images/si_reclaim.png" class="game_card_logo"></a></div>
-					<div class="game_link"><a href="https://sick.oberien.de/?query=" target="_blank"><img src="images/si_minor.png" class="game_card_logo"></a></div>
+					<div class="game_link">
+						<a href="https://boardgamegeek.com/boardgame/162886/spirit-island" target="_blank">
+							<img src="images/bgg_logo.svg" class="game_card_logo" alt="Spirit Island on BoardGameGeek" />
+						</a>
+					</div>
+					<div class="game_link">
+						<a href="https://spiritislandwiki.com/index.php?title=Main_Page" target="_blank">
+							<img src="images/si_reclaim.png" class="game_card_logo" alt="Spirit Island Wiki" />
+						</a>
+					</div>
+					<div class="game_link">
+						<a href="https://sick.oberien.de/?query=" target="_blank">
+							<img src="images/si_minor.png" class="game_card_logo" alt="Spirit Island Card Catalog" />
+						</a>
+					</div>
 				</div>
     	</div>
     	<div class="game_card"></div>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     	<p>I'm hosted with GitHub pages.</p>
 			<!--Game cards. Currently hardcoded, eventually will load from the database somehow.-->
     	<div class="game_card">
-    		<img src="images/spirit_island.webp" class="game_card_img">
+    		<img src="images/spirit_island.webp" class="game_card_img" alt="Spirit Island board game cover image">
     		<h1>Spirit Island</h1>
     		<p>Island Spirits join forces using elemental powers to defend their home from invaders.</p>
     		<div class="game_links">


### PR DESCRIPTION
Just some accessibility related fixes for the Spirit Island game link that I see on the homepage. None are a big deal in the context of this site and the audience we have for it for now, but it's good to get into the habit of writing accessible HTML early so you don't have to unlearn bad habits later. :)

Ultimately it all revolves around missing `alt` attributes that are required, even if you were to just leave them empty. This is especially important if you add a link to an image, because a screen reader will (try to) use the alt text to describe the link to a user if there is no other text available otherwise. So if the image has no alt attribute, or an empty alt attribute, and there is no other text inside of the `<a>` tag it will simply say "Link" or "Linked Image" and call it a day.

For some resources on this, here's these:
https://www.w3.org/TR/WCAG20-TECHS/H30.html
https://www.w3.org/WAI/tutorials/images/decision-tree/
